### PR TITLE
Fixing getitem_and_getattr_4

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -295,7 +295,7 @@ def getitem_and_getattr_4():
             'name': 'maple'
         }]
 
-    new_result = '{p.type}: {p.kinds[0].name}'.format(p=Plant())
+    new_result = '{p.type}: {p.kinds[0][name]}'.format(p=Plant())
 
     assert new_result == 'tree: oak'  # output
 


### PR DESCRIPTION
```
2.7.9 (default, Dec 10 2014, 12:28:03) [MSC v.1500 64 bit (AMD64)]
Traceback (most recent call last):
    new_result = '{p.type}: {p.kinds[0].name}'.format(p=Plant())
AttributeError: 'dict' object has no attribute 'name'
```