### PR TITLE
Updated Python versions

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -77,7 +77,7 @@
                         With this site we try to show you the most common use-cases covered by the <a href="https://docs.python.org/2/library/stdtypes.html#string-formatting">old</a> and <a href="https://docs.python.org/3/library/string.html#string-formatting">new</a> style string formatting API with practical examples.
                     </p>
                     <p>
-                        If not otherwise stated all examples work with Python 2.7, 3.2, 3.3, and 3.4 without requiring any additional libraries or monkey-patching.
+                        If not otherwise stated all examples work with Python 2.7, 3.2, 3.3, 3.4, and 3.5 without requiring any additional libraries or monkey-patching.
                     </p>
                     <p>
                         Further details about these two formatting methods can be found in the official Python documentation:


### PR DESCRIPTION
Added 3.5 to list of python versions that are supported by the .format() methods