### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,15 @@ from setuptools import setup
 setup(
     name='pyformat_site',
     install_requires=[
-        "click==4.0",
-        "jinja2==2.7.3",
+        "click==6.6",
+        "jinja2==2.8",
         "python-rex==0.4",
-        "libsass==0.8.2",
-        "Markdown==2.6.2",
-        "pytest==2.8.7",
-        "Pygments==2.0.2",
-        "astunparse==1.2.2",
-        "pytz==2015.4",
+        "libsass==0.11.1",
+        "Markdown==2.6.6",
+        "pytest==2.9.2",
+        "Pygments==2.1.3",
+        "astunparse==1.4.0",
+        "pytz==2016.6.1",
     ],
     entry_points={
         'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,32,33,34,35},coverage
+envlist = py{27,33,34,35},coverage
 
 [testenv]
 commands =
@@ -8,7 +8,7 @@ commands =
 deps =
     pytest
     pytest-sugar
-    coverage==4.0b3
+    coverage==4.2
     wrapt
 
 [testenv:coverage]
@@ -18,4 +18,4 @@ commands =
     coverage report --show-missing
 
 deps =
-    coverage==4.0b3
+    coverage==4.2


### PR DESCRIPTION
Update dependencies. The `astunparse` is broken on Python 3.5 without update. The newer version of `astunparse` with fix some issues related to Python 3.5's AST modification.