### PR TITLE
Added samples of nested formats

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -451,7 +451,7 @@ def test_nested_prec():
 
     new_result = '{:.{prec}} = {:.{prec}}'.format('Gibberish', 2.7182818284, prec=3)
 
-    assert new_result = 'Gib = 2.72'  # output
+    assert new_result == 'Gib = 2.72'  # output
 
 
 def test_nested_prec_2():
@@ -462,7 +462,7 @@ def test_nested_prec_2():
 
     new_result = '{:{prec}} = {:{prec}}'.format('Gibberish', 2.7182818284, prec='.3')
 
-    assert new_result = 'Gib = 2.72'  # output
+    assert new_result == 'Gib = 2.72'  # output
 
 
 def test_nested_date():
@@ -474,7 +474,7 @@ def test_nested_date():
 
     new_result = '{:{dfmt} {tfmt}}'.format(datetime(2001, 2, 3, 4, 5), dfmt='%Y-%m-%d', tfmt='%H:%M')
 
-    assert new_result = '2001-02-03 04:05'  # output
+    assert new_result == '2001-02-03 04:05'  # output
 
 
 def test_nested_order_1():
@@ -485,7 +485,7 @@ def test_nested_order_1():
 
     new_result = '{:{}{}{}.{}}'.format(2.7182818284, '>', '+', 10, 3)
 
-    assert new_result = '     +2.72'  # output
+    assert new_result == '     +2.72'  # output
 
 
 def test_nested_order_2():
@@ -495,7 +495,7 @@ def test_nested_order_2():
 
     new_result = '{:{}{sign}{}.{}}'.format(2.7182818284, '>', 10, 3, sign='+')
 
-    assert new_result = '     +2.72'  # output
+    assert new_result == '     +2.72'  # output
 
 
 def test_custom_1():

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -121,21 +121,6 @@ def test_string_pad_align_2():
     assert old_result == 'test      '  # output
 
 
-def test_string_variable_pad_align():
-    """
-    By argument:
-
-    In the previous example, the value '10' is encoded as part of the format
-    string.  However, it is possible to also supply such values as an
-    argument.
-    """
-    old_result = '%*s' % (-8, 'test')
-    new_result = '{:<{}s}'.format('test', 8)
-
-    assert old_result == new_result
-    assert old_result == 'test    '  # output
-
-
 def test_string_pad_align_3():
     """
     Again, new style formatting surpasses the old variant by providing more
@@ -175,17 +160,6 @@ def test_string_truncating():
 
     assert old_result == new_result
     assert old_result == 'xylop'  # output
-
-
-def test_string_truncate_2():
-    """
-    By argument:
-    """
-    old_result = '%.*s' % (7, 'xylophone', )
-    new_result = '{:.{}}'.format('xylophone', 7)
-
-    assert old_result == new_result
-    assert old_result == 'xylopho'  # output
 
 
 def test_string_trunc_pad():
@@ -421,20 +395,14 @@ def test_datetime():
     assert new_result == '2001-02-03 04:05'  # output
 
 
-def test_nested_align():
+def test_param_align():
     """
-    # Nested Formats
+    # Parametrized formats
 
     Additionally, new style formatting allows all of the components of
-    the format to be specified dynamically using nested formats.
-
-    Nested formats can be applied to every portion of the format after
-    the colon. Variable names can not be set dynamically because double
-    braces are the escape characters for braces, so something like
-    `'{{which}}'.format(0.1, 0.2, which=1)` would result in `'{which}'`,
-    not in `'0.2'`. Braces are not allowed in attribute names and item
-    indices are passed literally, so nested formats can not be used
-    anywhere before the colon in a format.
+    the format to be specified dynamically using parametrization. Parametrized
+    formats are nested expressions in braces that can appear anywhere in the
+    parent format after the colon.
 
     Dynamically select alignment:
     """
@@ -444,7 +412,7 @@ def test_nested_align():
     assert new_result == '   test   '  # output
 
 
-def test_nested_prec():
+def test_param_prec():
     """
     Dynamically selected precision:
     """
@@ -454,7 +422,7 @@ def test_nested_prec():
     assert new_result == 'Gib = 2.72'  # output
 
 
-def test_nested_prec_2():
+def test_param_prec_2():
     """
     The nested format can be used to replace *any* part of the format
     spec, so the precision example above could be rewritten as:
@@ -465,7 +433,7 @@ def test_nested_prec_2():
     assert new_result == 'Gib = 2.72'  # output
 
 
-def test_nested_date():
+def test_param_date():
     """
     The components of a date-time can be set separately:
     """
@@ -477,7 +445,7 @@ def test_nested_date():
     assert new_result == '2001-02-03 04:05'  # output
 
 
-def test_nested_order_1():
+def test_param_order_1():
     """
     The nested formats can be positional arguments. Position depends
     on the order of the opening curly braces:
@@ -488,7 +456,7 @@ def test_nested_order_1():
     assert new_result == '     +2.72'  # output
 
 
-def test_nested_order_2():
+def test_param_order_2():
     """
     And of course keyword arguments can be added to the mix as before:
     """

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -410,7 +410,7 @@ def test_datetime():
     """
     # Datetime
 
-    Additionally new style formatting allows objects to control their own
+    New style formatting also allows objects to control their own
     rendering. This for example allows datetime objects to be formatted inline:
     """
 
@@ -419,6 +419,83 @@ def test_datetime():
     new_result = '{:%Y-%m-%d %H:%M}'.format(datetime(2001, 2, 3, 4, 5))
 
     assert new_result == '2001-02-03 04:05'  # output
+
+
+def test_nested_align():
+    """
+    # Nested Formats
+
+    Additionally, new style formatting allows all of the components of
+    the format to be specified dynamically using nested formats.
+
+    Nested formats can be applied to every portion of the format after
+    the colon. Variable names can not be set dynamically because double
+    braces are the escape characters for braces, so something like
+    `'{{which}}'.format(0.1, 0.2, which=1)` would result in `'{which}'`,
+    not in `'0.2'`. Braces are not allowed in attribute names and item
+    indices are passed literally, so nested formats can not be used
+    anywhere before the colon in a format.
+
+    Dynamically select alignment:
+    """
+
+    new_result = '{:{align}{width}}'.format('test', align='^', width='10')
+
+    assert new_result == '   test   '  # output
+
+
+def test_nested_prec():
+    """
+    Dynamically selected precision:
+    """
+
+    new_result = '{:.{prec}} = {:.{prec}}'.format('Gibberish', 2.7182818284, prec=3)
+
+    assert new_result = 'Gib = 2.72'  # output
+
+
+def test_nested_prec_2():
+    """
+    The nested format can be used to replace *any* part of the format
+    spec, so the precision example above could be rewritten as:
+    """
+
+    new_result = '{:{prec}} = {:{prec}}'.format('Gibberish', 2.7182818284, prec='.3')
+
+    assert new_result = 'Gib = 2.72'  # output
+
+
+def test_nested_date():
+    """
+    The components of a date-time can be set separately:
+    """
+
+    from datetime import datetime
+
+    new_result = '{:{dfmt} {tfmt}}'.format(datetime(2001, 2, 3, 4, 5), dfmt='%Y-%m-%d', tfmt='%H:%M')
+
+    assert new_result = '2001-02-03 04:05'  # output
+
+
+def test_nested_order_1():
+    """
+    The nested formats can be positional arguments. Position depends
+    on the order of the opening curly braces:
+    """
+
+    new_result = '{:{}{}{}.{}}'.format(2.7182818284, '>', '+', 10, 3)
+
+    assert new_result = '     +2.72'  # output
+
+
+def test_nested_order_2():
+    """
+    And of course keyword arguments can be added to the mix as before:
+    """
+
+    new_result = '{:{}{sign}{}.{}}'.format(2.7182818284, '>', 10, 3, sign='+')
+
+    assert new_result = '     +2.72'  # output
 
 
 def test_custom_1():


### PR DESCRIPTION
Setting precision, width, etc. using positional and keyword arguments instead of fixing them in the string literal being formatted. This is something that I have always been uncertain about, so I made this PR.