### PR TITLE
The a flag is available with printf formatting

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -83,9 +83,11 @@ def test_ascii_conversion():
         def __repr__(self):
             return 'räpr'
 
+    old_result = '%s %a' % (Data(), Data())
     new_result = '{0!r} {0!a}'.format(Data())
 
     assert new_result == 'räpr r\\xe4pr'  # output
+    assert new_result == old_result
 
 
 def test_string_pad_align():

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -83,7 +83,7 @@ def test_ascii_conversion():
         def __repr__(self):
             return 'räpr'
 
-    old_result = '%s %a' % (Data(), Data())
+    old_result = '%r %a' % (Data(), Data())
     new_result = '{0!r} {0!a}'.format(Data())
 
     assert new_result == 'räpr r\\xe4pr'  # output


### PR DESCRIPTION
Currently pyformat.info says that printf-formatting doesn't do `ascii()`.