### PR TITLE
ENH: Added instruction for using + with =

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -292,6 +292,12 @@ def test_number_sign_4():
     assert new_result == '-  23'  # output
 
 
+def test_number_sign_5():
+    new_result = '{:=+5d}'.format(23)
+
+    assert new_result == '+  23'  # output
+
+
 def test_named_placeholders():
     """
     # Named placeholders


### PR DESCRIPTION
When I saw `{:=5d}'.format(-23)`, my immediate response was "how do I get the plus in there?". I figured others might have this question as well, especially since my knee-jerk response of doing `{:+=5d}'.format(23)` was wrong (yields `+++23`).