### PR TITLE
Keyword arguments are possible with placeholders

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -335,6 +335,7 @@ def test_named_placeholders_2():
     `.format()` also accepts keyword arguments.
     """
 
+    old_result = '%(first)s %(last)s' % dict(first="Hodor", last="Hodor!")
     new_result = '{first} {last}'.format(first="Hodor", last="Hodor!")
 
     assert new_result == 'Hodor Hodor!'  # output


### PR DESCRIPTION
Using a `dict()` to allow for keyword arguments is the obvious alternative for the new-style keyword arguments. It's a bit odd to say that this sn't supported.