### PR TITLE
docs: fix simple typo, curently -> currently

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ practical examples.
 
 ## Version 2
 
-We're curently working on [version 2](https://github.com/ulope/pyformat.info/tree/v2) 
+We're currently working on [version 2](https://github.com/ulope/pyformat.info/tree/v2) 
 of the site. This encompases a complete architecture change to use [Lektor](https://getlektor.com)
 to generate the site instead of the previous homegrown approach.
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `currently` rather than `curently`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md